### PR TITLE
更新官网 SEO 分享图

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,11 +23,11 @@
     <meta property="og:url" content="https://masterbao66.github.io/PayDance/" />
     <meta
       property="og:image"
-      content="https://masterbao66.github.io/PayDance/og-image.png"
+      content="https://raw.githubusercontent.com/MasterBao66/PayDance/main/docs/posters/poster-02-three-step-setup-v3.png"
     />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
-    <meta property="og:image:alt" content="薪跳 PayDance 产品 Logo" />
+    <meta property="og:image:width" content="1448" />
+    <meta property="og:image:height" content="1086" />
+    <meta property="og:image:alt" content="薪跳 PayDance 三步设置界面" />
     <meta property="og:site_name" content="薪跳 PayDance" />
     <meta property="og:locale" content="zh_CN" />
 
@@ -39,9 +39,9 @@
     />
     <meta
       name="twitter:image"
-      content="https://masterbao66.github.io/PayDance/og-image.png"
+      content="https://raw.githubusercontent.com/MasterBao66/PayDance/main/docs/posters/poster-02-three-step-setup-v3.png"
     />
-    <meta name="twitter:image:alt" content="薪跳 PayDance 产品 Logo" />
+    <meta name="twitter:image:alt" content="薪跳 PayDance 三步设置界面" />
 
     <script type="application/ld+json">
       {

--- a/src/web-preview.test.ts
+++ b/src/web-preview.test.ts
@@ -114,20 +114,29 @@ describe("PayDance Web Preview", () => {
     expect(webPreviewSource).not.toContain("@tauri-apps");
   });
 
-  it("brands the web storefront with the product logo and current version", () => {
+  it("brands the web storefront with the setup poster and current version", () => {
     const favicon = statSync(new URL("../public/favicon.png", import.meta.url));
-    const ogImage = statSync(new URL("../public/og-image.png", import.meta.url));
+    const sharePoster = statSync(
+      new URL("../docs/posters/poster-02-three-step-setup-v3.png", import.meta.url),
+    );
     const htmlSource = read("index.html");
+    const sharePosterUrl =
+      "https://raw.githubusercontent.com/MasterBao66/PayDance/main/docs/posters/poster-02-three-step-setup-v3.png";
 
     expect(webPreviewSource).toContain("productLogoUrl");
     expect(webPreviewSource).toContain("appVersion");
     expect(htmlSource).toContain('rel="icon"');
     expect(htmlSource).toContain("%BASE_URL%favicon.png");
     expect(favicon.size).toBeGreaterThan(1_000);
-    expect(ogImage.size).toBeGreaterThan(20_000);
-    expect(pngSize("public/og-image.png")).toEqual({ width: 1200, height: 630 });
-    expect(htmlSource).toContain("https://masterbao66.github.io/PayDance/og-image.png");
-    expect(ogImage.size).toBeLessThan(450_000);
+    expect(sharePoster.size).toBeGreaterThan(20_000);
+    expect(pngSize("docs/posters/poster-02-three-step-setup-v3.png")).toEqual({
+      width: 1448,
+      height: 1086,
+    });
+    expect(htmlSource.match(new RegExp(sharePosterUrl, "g"))).toHaveLength(2);
+    expect(htmlSource).toContain('<meta property="og:image:width" content="1448" />');
+    expect(htmlSource).toContain('<meta property="og:image:height" content="1086" />');
+    expect(htmlSource).toContain("薪跳 PayDance 三步设置界面");
     expect(htmlSource).toContain(
       "<title>薪跳 PayDance — Windows 桌面实时工资看板</title>",
     );


### PR DESCRIPTION
## 修改内容
- 将官网 Open Graph 和 Twitter 分享图替换为三步设置海报
- 同步图片尺寸与无障碍说明文字
- 更新自动化测试，防止分享图配置回退

## 验证
- `npm run verify:fast`
- 62 个测试文件、327 项测试全部通过
- 桌面版与网页版构建通过