### PR TITLE
test: fix incomplete hostname regular expression alert

### DIFF
--- a/scripts/repository-metadata.test.js
+++ b/scripts/repository-metadata.test.js
@@ -96,6 +96,12 @@ describe("repository metadata", () => {
     expect(existsInWorktree(posterPath)).toBe(true);
   });
 
+  it("keeps production URLs out of dynamically constructed regular expressions", () => {
+    const webPreviewTest = read("src/web-preview.test.ts");
+
+    expect(webPreviewTest).not.toContain("new RegExp(sharePosterUrl");
+  });
+
   it("keeps the root LICENSE recognizable as canonical AGPL-3.0", () => {
     const license = read("LICENSE");
     const normalizedLicense = license.replace(/\s+/g, " ");

--- a/src/web-preview.test.ts
+++ b/src/web-preview.test.ts
@@ -27,6 +27,8 @@ import appMetaSource from "./lib/app-meta.ts?raw";
 
 const read = (path: string) =>
   readFileSync(new URL(`../${path}`, import.meta.url), "utf8");
+const countLiteralOccurrences = (source: string, value: string) =>
+  source.split(value).length - 1;
 const pngSize = (path: string) => {
   const source = readFileSync(new URL(`../${path}`, import.meta.url));
   const pngSignature = "89504e470d0a1a0a";
@@ -135,8 +137,8 @@ describe("PayDance Web Preview", () => {
       width: 1448,
       height: 1086,
     });
-    expect(chineseHtmlSource.match(new RegExp(sharePosterUrl, "g"))).toHaveLength(2);
-    expect(englishHtmlSource.match(new RegExp(sharePosterUrl, "g"))).toHaveLength(2);
+    expect(countLiteralOccurrences(chineseHtmlSource, sharePosterUrl)).toBe(2);
+    expect(countLiteralOccurrences(englishHtmlSource, sharePosterUrl)).toBe(2);
     expect(chineseHtmlSource).toContain(
       '<meta property="og:image:width" content="1448" />',
     );


### PR DESCRIPTION
## Summary
- replace dynamic URL regular expressions with literal occurrence counting
- add a regression check preventing production URLs from being passed directly to RegExp
- resolve CodeQL alert #1: incomplete hostname regular expression

## Verification
- npm run verify:push
- 336 tests passed locally