### PR TITLE
ci: 修复 main 合并后的官网部署竞态

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ permissions:
 
 concurrency:
   group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   changes:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,7 +16,7 @@ permissions:
 
 concurrency:
   group: codeql-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   changes:

--- a/.github/workflows/web-preview.yml
+++ b/.github/workflows/web-preview.yml
@@ -17,7 +17,7 @@ permissions:
 
 concurrency:
   group: web-preview-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   scope:

--- a/scripts/ci-workflow.test.js
+++ b/scripts/ci-workflow.test.js
@@ -109,6 +109,22 @@ describe("CI workflow routing", () => {
     );
   });
 
+  it("does not cancel main validation or deployment runs", () => {
+    const ciWorkflow = readRoot(".github/workflows/ci.yml");
+    const codeqlWorkflow = readRoot(".github/workflows/codeql.yml");
+    const webPreviewWorkflow = readRoot(".github/workflows/web-preview.yml");
+
+    expect(ciWorkflow).toContain(
+      "cancel-in-progress: ${{ github.event_name == 'pull_request' }}",
+    );
+    expect(ciWorkflow).not.toContain("cancel-in-progress: true");
+    expect(codeqlWorkflow).toContain(
+      "cancel-in-progress: ${{ github.event_name == 'pull_request' }}",
+    );
+    expect(codeqlWorkflow).not.toContain("cancel-in-progress: true");
+    expect(webPreviewWorkflow).toContain("cancel-in-progress: false");
+  });
+
   it("runs CodeQL, Windows executable smoke, and release SBOM generation", () => {
     const codeqlWorkflow = readRoot(".github/workflows/codeql.yml");
     const releaseWorkflow = readRoot(".github/workflows/release.yml");


### PR DESCRIPTION
## 问题

PR #32 已合并，但紧随其后的更新日志提交取消了功能提交的 CI；文档提交自身又因变更范围判断跳过 Web Preview 部署，导致官网没有发布已合并功能。

## 修复

- PR 分支继续取消过期的 CI / CodeQL 运行
- main 分支的 CI / CodeQL 改为排队完成，确保每个已合并提交都经过验证
- Web Preview 部署改为排队，避免后续无需部署的运行取消正在发布的版本
- 增加工作流并发策略回归测试
- 保留 CHANGELOG.md 中已删除的“便于作品集和面试展示”文案

## 验证

- npx vitest run scripts/ci-workflow.test.js
- npm run verify:metadata
- git diff --check