### PR TITLE
fix(security): resolve brace-expansion advisory

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,7 @@ Select the checks relevant to your change. Explain why an item is not applicable
 
 - [ ] `npm run verify:metadata`
 - [ ] `npm run verify:fast`
-- [ ] `npm audit --omit=dev`
+- [ ] `npm audit --audit-level=high`
 - [ ] `Push-Location src-tauri; cargo fmt --all -- --check; cargo check; cargo clippy --all-targets -- -D warnings; cargo audit --deny warnings; cargo deny check --hide-inclusion-graph; Pop-Location`
 - [ ] `npm run qa:web-preview`
 - [ ] Windows 桌面端人工冒烟 / Windows desktop manual smoke test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,8 +206,8 @@ jobs:
       - name: Install frontend dependencies
         run: npm ci
 
-      - name: Audit production dependencies
-        run: npm audit --omit=dev
+      - name: Audit all npm dependencies
+        run: npm audit --audit-level=high
 
       - name: Install gitleaks (pre-built)
         run: |

--- a/docs/superpowers/plans/2026-07-22-dependabot-brace-expansion.md
+++ b/docs/superpowers/plans/2026-07-22-dependabot-brace-expansion.md
@@ -1,0 +1,209 @@
+# Dependabot brace-expansion 安全修复实现计划
+
+> **面向 AI 代理的工作者：** 必需子技能：使用 superpowers:subagent-driven-development（推荐）或 superpowers:executing-plans 逐任务实现此计划。步骤使用复选框（`- [ ]`）语法来跟踪进度。
+
+**目标：** 清除 PayDance 的 `GHSA-3jxr-9vmj-r5cp` Dependabot 高危警报，并确保开发依赖与间接依赖以后进入本地和 CI 的安全审计门禁。
+
+**架构：** 先用 `npm audit --audit-level=high` 作为可复现的失败用例，再只更新锁文件中受影响的 `brace-expansion` 实例。Dependabot updater 对本次多版本间接依赖连续返回 `update_not_possible`；同时 npm 的 `allow: dependency-type: "all"` 只允许清单中的显式依赖，反而会缩小默认安全更新范围。因此可靠防线是手工最小锁文件更新，并把全依赖高危审计接入发布脚本和 CI。
+
+**技术栈：** npm 11、Vitest、GitHub Actions、Dependabot、Vue 3、Tauri/Rust
+
+---
+
+### 任务 1：锁定安全治理契约
+
+**文件：**
+- 修改：`scripts/verify-scripts.test.js`
+- 修改：`scripts/ci-workflow.test.js`
+
+- [ ] **步骤 1：编写失败的测试**
+
+在 `scripts/verify-scripts.test.js` 中要求发布校验包含全部 npm 依赖的高危审计：
+
+```js
+const releaseCommands = packageJson.scripts["verify:release"]
+  .split("&&")
+  .map((command) => command.trim());
+
+expect(releaseCommands).toContain("npm audit --audit-level=high");
+expect(releaseCommands).not.toContain("npm audit --omit=dev");
+expect(packageJson.scripts["verify:release"]).not.toMatch(
+  /\bnpm audit\b[^&]*(?:--omit(?:=|\s+)dev)\b/,
+);
+```
+
+在 `scripts/ci-workflow.test.js` 中要求 CI 使用相同门禁：
+
+```js
+expect(ciWorkflow).toMatch(
+  /- name: Audit all npm dependencies\r?\n\s+run: npm audit --audit-level=high(?:\r?\n|$)/,
+);
+expect(ciWorkflow).not.toMatch(
+  /\bnpm audit\b[^\r\n]*(?:--omit(?:=|\s+)dev)\b/,
+);
+expect(ciWorkflow).not.toMatch(/\bNPM_CONFIG_OMIT:\s*dev\b/);
+```
+
+- [ ] **步骤 2：运行测试验证失败**
+
+运行：
+
+```powershell
+npx vitest run scripts/verify-scripts.test.js scripts/ci-workflow.test.js
+```
+
+预期：FAIL；失败点应是旧发布脚本和 CI 仍使用 `npm audit --omit=dev`。
+
+- [ ] **步骤 3：保持测试改动最小**
+
+确认没有改动业务源码，也没有放宽已有断言；新断言只描述本次安全门禁。
+
+- [ ] **步骤 4：再次运行目标测试确认仍为预期失败**
+
+运行：
+
+```powershell
+npx vitest run scripts/verify-scripts.test.js scripts/ci-workflow.test.js
+```
+
+预期：FAIL，且原因与步骤 2 一致。
+
+- [ ] **步骤 5：Commit**
+
+目标测试与实现紧密耦合，本任务完成后与任务 2 一起提交，避免提交一个必然失败的中间状态。
+
+### 任务 2：修复锁文件并补齐自动化门禁
+
+**文件：**
+- 修改：`package-lock.json`
+- 修改：`package.json`
+- 修改：`.github/workflows/ci.yml`
+- 修改：`.github/PULL_REQUEST_TEMPLATE.md`
+- 测试：`scripts/verify-scripts.test.js`
+- 测试：`scripts/ci-workflow.test.js`
+
+- [ ] **步骤 1：更新受影响的间接依赖**
+
+运行：
+
+```powershell
+npm audit fix --package-lock-only
+```
+
+预期：`brace-expansion` 的两个 2.x 实例更新到 `2.1.2`，5.x 实例更新到 `5.0.7`，其他直接依赖声明不变。
+
+- [ ] **步骤 2：配置发布与 CI 高危门禁**
+
+将 `package.json` 的发布审计片段改为：
+
+```json
+"npm audit --audit-level=high"
+```
+
+将 `.github/workflows/ci.yml` 的审计步骤改为：
+
+```yaml
+- name: Audit all npm dependencies
+  run: npm audit --audit-level=high
+```
+
+并将 `.github/PULL_REQUEST_TEMPLATE.md` 的对应人工检查项同步为 `npm audit --audit-level=high`。
+
+- [ ] **步骤 3：运行目标测试验证通过**
+
+运行：
+
+```powershell
+npx vitest run scripts/verify-scripts.test.js scripts/ci-workflow.test.js
+```
+
+预期：PASS。
+
+- [ ] **步骤 4：验证漏洞已消失**
+
+运行：
+
+```powershell
+npm audit --audit-level=high
+npm ls brace-expansion --all
+```
+
+预期：`found 0 vulnerabilities`；依赖树只包含 `brace-expansion@2.1.2` 和 `brace-expansion@5.0.7`。
+
+- [ ] **步骤 5：Commit**
+
+```powershell
+git add package-lock.json package.json .github/workflows/ci.yml .github/PULL_REQUEST_TEMPLATE.md scripts/verify-scripts.test.js scripts/ci-workflow.test.js docs/superpowers/plans/2026-07-22-dependabot-brace-expansion.md
+git commit -m "fix(security): resolve brace-expansion advisory"
+```
+
+### 任务 3：完整验证与发布
+
+**文件：**
+- 验证：全部已修改文件和现有前端、Rust 项目
+
+- [ ] **步骤 1：运行前端快速验证**
+
+运行：
+
+```powershell
+npm run verify:fast
+```
+
+预期：lint、格式、351 个现有测试及桌面/Web 构建全部通过。
+
+- [ ] **步骤 2：运行元数据验证**
+
+运行：
+
+```powershell
+npm run verify:metadata
+```
+
+预期：安全治理契约、CI 范围和仓库元数据测试全部通过，`git diff --check` 无错误。
+
+- [ ] **步骤 3：运行 Rust 验证**
+
+运行：
+
+```powershell
+Push-Location src-tauri
+cargo fmt --all -- --check
+cargo check
+cargo clippy --all-targets -- -D warnings
+cargo test
+Pop-Location
+```
+
+预期：全部通过，0 条警告。
+
+- [ ] **步骤 4：推送分支并创建 PR**
+
+```powershell
+git push -u origin codex/fix-dependabot-brace-expansion
+gh pr create --base main --head codex/fix-dependabot-brace-expansion --title "fix(security): resolve brace-expansion advisory"
+```
+
+预期：PR 创建成功，`CI gate` 与 `CodeQL gate` 启动。
+
+- [ ] **步骤 5：等待必需检查并合并**
+
+运行：
+
+```powershell
+gh pr checks --watch --fail-fast
+gh pr merge --squash --delete-branch
+```
+
+预期：必需检查通过，PR 合并到 `main`。
+
+- [ ] **步骤 6：确认警报关闭**
+
+运行：
+
+```powershell
+gh api repos/MrBaoboer/PayDance/dependabot/alerts/2 --jq '.state'
+gh api "repos/MrBaoboer/PayDance/dependabot/alerts?state=open"
+```
+
+预期：第一条命令输出 `fixed`，直接确认警报 #2 已修复；第二条命令独立返回空数组，确认没有其他开放警报；默认分支 `npm audit --audit-level=high` 为 0 个漏洞。

--- a/package-lock.json
+++ b/package-lock.json
@@ -2069,9 +2069,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2255,9 +2255,9 @@
       "license": "MIT"
     },
     "node_modules/editorconfig/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2735,9 +2735,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "verify:metadata": "npm run version:check && npm run check:hygiene && npm run format:check && npx vitest run scripts/repository-metadata.test.js scripts/verify-scripts.test.js scripts/ci-change-scope.test.js scripts/ci-workflow.test.js scripts/source-header.test.js scripts/build-latest-json.test.js scripts/assert-build-target.test.js scripts/web-seo.test.js && git diff --check",
     "verify:push": "node scripts/push-workflow.mjs --verify-only",
     "push:main": "node scripts/push-workflow.mjs",
-    "verify:release": "npm run verify:fast && npm run version:check && npm run release:check && npm audit --omit=dev && cd src-tauri && cargo fmt --all -- --check && cargo check && cargo clippy --all-targets -- -D warnings && cargo test && cargo audit && cargo deny check",
+    "verify:release": "npm run verify:fast && npm run version:check && npm run release:check && npm audit --audit-level=high && cd src-tauri && cargo fmt --all -- --check && cargo check && cargo clippy --all-targets -- -D warnings && cargo test && cargo audit && cargo deny check",
     "verify:release:record": "npm run verify:release && node scripts/verification-evidence.mjs write verify:release",
     "release:publish": "node scripts/release-workflow.mjs",
     "qa:web-preview": "node scripts/qa-web-preview.mjs",

--- a/scripts/ci-workflow.test.js
+++ b/scripts/ci-workflow.test.js
@@ -83,6 +83,13 @@ describe("CI workflow routing", () => {
     expect(ciWorkflow).toContain("Upload Web Preview QA evidence");
     expect(ciWorkflow).toContain("Security audit");
     expect(ciWorkflow).toContain("if: needs.changes.outputs.requires_security == 'true'");
+    expect(ciWorkflow).toMatch(
+      /- name: Audit all npm dependencies\r?\n\s+run: npm audit --audit-level=high(?:\r?\n|$)/,
+    );
+    expect(ciWorkflow).not.toMatch(
+      /\bnpm audit\b[^\r\n]*(?:--omit(?:=|\s+)dev)\b/,
+    );
+    expect(ciWorkflow).not.toMatch(/\bNPM_CONFIG_OMIT:\s*dev\b/);
     expect(ciWorkflow).toContain("name: Rust checks");
     expect(ciWorkflow).toContain("if: needs.changes.outputs.requires_rust == 'true'");
     expect(ciWorkflow).toContain("Run Rust tests");

--- a/scripts/verify-scripts.test.js
+++ b/scripts/verify-scripts.test.js
@@ -60,8 +60,16 @@ describe("verification scripts", () => {
       "node scripts/assert-build-boundary.mjs desktop",
     );
 
+    const releaseCommands = packageJson.scripts["verify:release"]
+      .split("&&")
+      .map((command) => command.trim());
+
     expect(packageJson.scripts["verify:release"]).toContain("npm run version:check");
-    expect(packageJson.scripts["verify:release"]).toContain("npm audit --omit=dev");
+    expect(releaseCommands).toContain("npm audit --audit-level=high");
+    expect(releaseCommands).not.toContain("npm audit --omit=dev");
+    expect(packageJson.scripts["verify:release"]).not.toMatch(
+      /\bnpm audit\b[^&]*(?:--omit(?:=|\s+)dev)\b/,
+    );
     expect(packageJson.scripts["verify:release"]).toContain("cargo fmt --all -- --check");
     expect(packageJson.scripts["verify:release"]).toContain(
       "cargo clippy --all-targets -- -D warnings",


### PR DESCRIPTION
## 摘要

- 将三个受 `GHSA-3jxr-9vmj-r5cp` / `CVE-2026-13149` 影响的 `brace-expansion` 间接依赖锁定版本升级到 `2.1.2` 和 `5.0.7`
- 将发布流程、CI 与 PR 检查统一为 `npm audit --audit-level=high`，覆盖开发依赖与间接依赖
- 增加安全门禁回归测试，防止重新使用 `--omit=dev`

## 根因

GitHub Dependabot 连续两次尝试自动更新，但对同时存在 2.x 与 5.x 的 npm 间接依赖返回 `update_not_possible`，未创建安全更新 PR；同时现有 CI 只审计生产依赖，因此未能阻止该开发依赖高危漏洞。

## 影响

不改动业务源码或直接依赖 API。合并后默认分支的 Dependabot 高危警报 #2 将由修复后的锁文件关闭，后续高危开发/间接依赖漏洞会被 CI 与发布门禁拦截。

## 验证

- `npm run verify:fast`（66 个测试文件、351 个测试）
- `npm run verify:metadata`（8 个测试文件、43 个测试）
- `npm audit --audit-level=high`（0 vulnerabilities）
- `npm ls brace-expansion --all`（仅 `2.1.2`、`5.0.7`）
- `cargo fmt --all -- --check`
- `cargo check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`（6 个测试）