### PR TITLE
chore(deps): 升级依赖与工具链，并用 Dependabot 接管依赖更新

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 * text=auto
 
 LICENSE text eol=lf
+Cargo.lock text eol=lf
 
 *.css text eol=lf
 *.html text eol=lf

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,106 @@
+# Dependabot 依赖更新配置
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates
+#
+# 为什么是 Dependabot 而不是 Renovate：.github/renovate.json 从未被任何机器人执行过
+# （仓库里 app/renovate 活动数为 0）。Dependabot 是 GitHub 原生能力，合并本文件即生效，
+# 不需要安装任何 App。分组、标签、人工审核策略与 renovate.json 保持一致。
+#
+# 三个 ecosystem 都不开 automerge：升级 PR 必须过 CI 门禁并由人确认后再合。
+
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Shanghai
+    labels:
+      - dependencies
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: chore(deps)
+      prefix-development: chore(deps-dev)
+    groups:
+      tauri:
+        patterns:
+          - "@tauri-apps/*"
+      vue:
+        patterns:
+          - vue
+          - vue-tsc
+          - "@vitejs/plugin-vue"
+          - "@vue/test-utils"
+          - eslint-plugin-vue
+          - eslint-plugin-vuejs-accessibility
+      build-tooling:
+        patterns:
+          - vite
+          - vitest
+          - happy-dom
+          - "@tailwindcss/vite"
+          - tailwindcss
+      linting:
+        patterns:
+          - eslint
+          - prettier
+          - typescript-eslint
+          - "@eslint/js"
+          - eslint-config-prettier
+    # 只挡主版本跳跃，6.x / 24.x 范围内的小版本照常提 PR。
+    # 解除封锁时删掉对应条目即可。
+    ignore:
+      # TypeScript 7 是原生移植版：vue-tsc 无法从中解析 tsc.js
+      # （ERR_PACKAGE_PATH_NOT_EXPORTED），typescript-eslint 直接抛
+      # "does not support TS 7.0" 拒绝启动。等两者宣布支持后删掉本条。
+      - dependency-name: typescript
+        update-types:
+          - version-update:semver-major
+      # @types/node 跟随运行时主版本：CI 与本地都是 Node 24 LTS，
+      # 类型版本超前会让编译期接受运行时并不存在的 API。
+      # 升级 CI 的 node-version 时同步放开本条。
+      - dependency-name: "@types/node"
+        update-types:
+          - version-update:semver-major
+
+  - package-ecosystem: cargo
+    directory: /src-tauri
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Shanghai
+    labels:
+      - dependencies
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: chore(deps)
+    groups:
+      tauri:
+        patterns:
+          - tauri
+          - tauri-build
+          - "tauri-plugin-*"
+      rust-serde:
+        patterns:
+          - serde
+          - serde_json
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Shanghai
+    labels:
+      - dependencies
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: chore(ci)
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -49,7 +49,16 @@
     {
       "matchPackageNames": ["typescript"],
       "groupName": "TypeScript",
-      "groupSlug": "typescript"
+      "groupSlug": "typescript",
+      "allowedVersions": "<7",
+      "description": "TypeScript 7 是原生移植版：vue-tsc 无法从中解析 tsc.js，typescript-eslint 直接拒绝启动。等两者宣布支持 TS 7 后再放开此上限。"
+    },
+    {
+      "matchPackageNames": ["@types/node"],
+      "groupName": "Node types",
+      "groupSlug": "node-types",
+      "allowedVersions": "<25",
+      "description": "锁定在运行时主版本上：CI 与本地均使用 Node 24 LTS，类型版本超前会让编译期接受运行时不存在的 API。"
     },
     {
       "matchPackageNames": ["@lucide/vue"],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - name: Cache Rust build
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
@@ -209,7 +209,11 @@ jobs:
       - name: Audit all npm dependencies
         run: npm audit --audit-level=high
 
+      # 后续审计步骤统一带 `if: '!cancelled()'`：任一审计失败时其余仍然执行，
+      # 一次 CI 就能拿到 npm / gitleaks / cargo-audit / cargo-deny 的完整结论，
+      # 而不是修完第一个才发现还有第二个。任一步失败该 job 依然是红的。
       - name: Install gitleaks (pre-built)
+        if: "!cancelled()"
         run: |
           version="8.30.1"
           url="https://github.com/gitleaks/gitleaks/releases/download/v${version}/gitleaks_${version}_linux_x64.tar.gz"
@@ -221,9 +225,11 @@ jobs:
           sudo mv gitleaks /usr/local/bin/
 
       - name: Run gitleaks (detect secrets in git history)
+        if: "!cancelled()"
         run: gitleaks detect --config .gitleaks.toml --verbose
 
       - name: Install cargo-audit (pre-built)
+        if: "!cancelled()"
         run: |
           version="0.22.2"
           url="https://github.com/rustsec/rustsec/releases/download/cargo-audit/v${version}/cargo-audit-x86_64-unknown-linux-gnu-v${version}.tgz"
@@ -234,10 +240,12 @@ jobs:
           sudo mv "cargo-audit-x86_64-unknown-linux-gnu-v${version}/cargo-audit" /usr/local/bin/
 
       - name: Audit Rust dependencies
+        if: "!cancelled()"
         run: cargo audit
         working-directory: src-tauri
 
       - name: Install cargo-deny (pre-built)
+        if: "!cancelled()"
         run: |
           version="0.20.2"
           url="https://github.com/EmbarkStudios/cargo-deny/releases/download/${version}/cargo-deny-${version}-x86_64-unknown-linux-musl.tar.gz"
@@ -248,6 +256,7 @@ jobs:
           sudo mv "cargo-deny-${version}-x86_64-unknown-linux-musl/cargo-deny" /usr/local/bin/
 
       - name: Check Rust dependency licenses and sources
+        if: "!cancelled()"
         run: cargo deny check
         working-directory: src-tauri
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
           cache: npm
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - name: Cache Rust build
         uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2

--- a/docs/MAINTENANCE.md
+++ b/docs/MAINTENANCE.md
@@ -48,9 +48,15 @@ Release workflow 还会运行 `scripts/smoke-windows-exe.ps1`，自动确认便�
 - 程序功能、Bug 修复、依赖升级、发布流程和安全相关修改优先走 PR，并等待 CI 与 CodeQL 通过。
 - 纯文档变更仍保留 `CI gate` 与 `CodeQL gate`，但 CodeQL 会跳过耗时的 JavaScript 和 Rust 分析。
 
-## Renovate
+## 依赖更新
 
-- 配置位于 `.github/renovate.json`，可运行 `npx --yes --package renovate renovate-config-validator .github/renovate.json` 验证。
-- 当前采用立即检查、无限并发 PR、全部人工评估的模式；禁止 Renovate 自动合并。
-- Hosted App 正常运行的公开证据是 Renovate PR 或 `Dependency Dashboard` Issue；仅存在配置文件不等于机器人已经安装。
-- 配置合入 `main` 后应立即确认 Dashboard 和首轮 PR；没有活动时，在 GitHub App 设置中重新确认仓库授权。
+- **生效中的是 Dependabot**，配置位于 `.github/dependabot.yml`，覆盖 npm、cargo、github-actions 三个 ecosystem，每周一 09:00（Asia/Shanghai）检查，分组与人工评估策略照搬 renovate.json，不开自动合并。
+- `.github/renovate.json` 保留但**从未被执行过**：2026-08-08 查证，仓库内 `app/renovate` 活动数为 0，历史 PR 无一来自它，issue #25「依赖更新面板」是手写的占位 issue 而非 renovate[bot] 产出。上一条约定「仅存在配置文件不等于机器人已经安装」当时写对了，但一直没人去验证。
+- 若日后真的安装了 Renovate Hosted App，需同时删除 `.github/dependabot.yml`，否则两边会重复提 PR。
+- 被上游卡住、故意不升的依赖写在三处并保持同步：`dependabot.yml` 的 `ignore`、`renovate.json` 的 `allowedVersions`、以及 `scripts/repository-metadata.test.js` 里 “keeps the upgrades that are blocked upstream pinned with a reason”。当前有两条：`typescript` 锁在 6.x（TS 7 是原生移植版，vue-tsc 解析不到 `tsc.js`，typescript-eslint 拒绝加载），`@types/node` 锁在 24.x（跟随运行时主版本）。
+- **2026-10 待办**：Node 26 转为 LTS 后，把 CI 各处 `node-version` 推到 26，同步放开 `@types/node` 的 major 封锁并删掉对应测试断言。
+
+## 本地工具链对齐
+
+- CI 的 Rust 用 `stable`，本地落后会导致 `cargo clippy -D warnings` 的结论与 CI 不一致。定期 `rustup update stable`（含 `rustup check` 先看差距）。
+- `npm run verify:release` 调用的是**本地**的 cargo-audit / cargo-deny，而 CI 装的是固定版本。两边版本不一致时本地结论不作数，用 `cargo install cargo-audit cargo-deny --locked` 追平。

--- a/docs/MAINTENANCE_EN.md
+++ b/docs/MAINTENANCE_EN.md
@@ -48,9 +48,15 @@ The Release workflow also runs `scripts/smoke-windows-exe.ps1` to confirm that t
 - Product features, bug fixes, dependency upgrades, release workflows, and security-related changes should normally use a PR and wait for CI and CodeQL.
 - Documentation-only changes still report `CI gate` and `CodeQL gate`, while CodeQL skips the expensive JavaScript and Rust analysis jobs.
 
-## Renovate
+## Dependency Updates
 
-- Configuration lives in `.github/renovate.json`; validate it with `npx --yes --package renovate renovate-config-validator .github/renovate.json`.
-- Renovate runs immediately with unlimited concurrent PRs and mandatory human merge assessment. Automerge is disabled.
-- Public evidence of a working hosted app is a Renovate PR or a `Dependency Dashboard` Issue. A config file alone does not prove installation.
-- After the configuration reaches `main`, confirm the Dashboard and first PR batch immediately. If nothing appears, reconfirm repository access in the GitHub App settings.
+- **Dependabot is the live automation.** Configuration lives in `.github/dependabot.yml` and covers the npm, cargo, and github-actions ecosystems, checking every Monday at 09:00 Asia/Shanghai. Grouping and human-review policy mirror renovate.json; automerge is disabled.
+- `.github/renovate.json` is kept but **has never run**. Verified on 2026-08-08: the repository shows zero activity from `app/renovate`, no historical PR came from it, and issue #25 "Dependency Dashboard" is a hand-written placeholder rather than renovate[bot] output. The previous note — a config file alone does not prove installation — was correct but nobody ever checked.
+- If the Renovate hosted app is genuinely installed later, delete `.github/dependabot.yml` at the same time, otherwise both bots will raise duplicate PRs.
+- Upgrades that are deliberately held back live in three places that must stay in sync: the `ignore` block in `dependabot.yml`, `allowedVersions` in `renovate.json`, and the "keeps the upgrades that are blocked upstream pinned with a reason" test in `scripts/repository-metadata.test.js`. Two entries today: `typescript` is held at 6.x (TypeScript 7 is the native port — vue-tsc cannot resolve `tsc.js` from it and typescript-eslint refuses to load), and `@types/node` is held at 24.x to track the runtime major.
+- **October 2026 follow-up**: once Node 26 reaches LTS, move every CI `node-version` to 26, lift the `@types/node` major block, and drop the matching test assertion.
+
+## Local Toolchain Alignment
+
+- CI uses Rust `stable`. A lagging local toolchain makes `cargo clippy -D warnings` disagree with CI. Run `rustup check` to see the gap and `rustup update stable` to close it.
+- `npm run verify:release` invokes the **local** cargo-audit and cargo-deny, while CI installs pinned versions. When the two differ, the local result does not count — realign with `cargo install cargo-audit cargo-deny --locked`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@eslint/js": "^10.0.1",
         "@tailwindcss/vite": "^4.3.0",
         "@tauri-apps/cli": "^2.11.2",
-        "@types/node": "^26.2.0",
+        "@types/node": "^24.13.3",
         "@types/pngjs": "^6.0.5",
         "@vitejs/plugin-vue": "^6.0.7",
         "@vue/test-utils": "^2.4.10",
@@ -1283,13 +1283,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.2.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
-      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~8.3.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/pngjs": {
@@ -3873,9 +3873,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@eslint/js": "^10.0.1",
     "@tailwindcss/vite": "^4.3.0",
     "@tauri-apps/cli": "^2.11.2",
-    "@types/node": "^26.2.0",
+    "@types/node": "^24.13.3",
     "@types/pngjs": "^6.0.5",
     "@vitejs/plugin-vue": "^6.0.7",
     "@vue/test-utils": "^2.4.10",

--- a/scripts/repository-metadata.test.js
+++ b/scripts/repository-metadata.test.js
@@ -12,6 +12,11 @@ const repoRoot = resolve(import.meta.dirname, "..");
 const read = (path) => readFileSync(resolve(repoRoot, path), "utf8");
 const packageJson = JSON.parse(read("package.json"));
 const renovateConfig = JSON.parse(read(".github/renovate.json"));
+const dependabotConfig = read(".github/dependabot.yml");
+const dependabotSettings = dependabotConfig
+  .split(/\r?\n/)
+  .filter((line) => !line.trim().startsWith("#"))
+  .join("\n");
 const versionedDesktopAssetName = `pay-dance-v${packageJson.version}-windows-x64.exe`;
 const desktopDownloadUrl = `https://github.com/MrBaoboer/PayDance/releases/latest/download/${versionedDesktopAssetName}`;
 const legacyAdditionalTermsReference = `see /${["ADDITIONAL_TERMS", "md"].join(".")}`;
@@ -63,9 +68,44 @@ describe("repository metadata", () => {
     expect(renovateConfig.prConcurrentLimit).toBe(0);
     expect(renovateConfig.prHourlyLimit).toBe(0);
     expect(renovateConfig.schedule).toBeUndefined();
+    expect(renovateConfig.packageRules.some((rule) => rule.automerge === true)).toBe(
+      false,
+    );
+  });
+
+  it("keeps Dependabot covering every ecosystem and human-reviewed", () => {
+    for (const ecosystem of ["npm", "cargo", "github-actions"]) {
+      expect(dependabotConfig).toContain(`package-ecosystem: ${ecosystem}`);
+    }
+    expect(dependabotConfig).toContain("directory: /src-tauri");
+    expect(dependabotConfig).toMatch(/interval: weekly/);
+    // Comments mention automerge on purpose; only actual settings must not.
+    expect(dependabotSettings).not.toMatch(/automerge/i);
+  });
+
+  it("keeps the upgrades that are blocked upstream pinned with a reason", () => {
+    // TypeScript 7 breaks vue-tsc (ERR_PACKAGE_PATH_NOT_EXPORTED) and
+    // typescript-eslint refuses to load against it. @types/node must track the
+    // Node 24 LTS runtime that CI and local development both use.
+    expect(packageJson.devDependencies.typescript).toMatch(/^\^6\./);
+    expect(packageJson.devDependencies["@types/node"]).toMatch(/^\^24\./);
+    for (const name of ["typescript", '"@types/node"']) {
+      expect(dependabotSettings).toMatch(
+        new RegExp(
+          `dependency-name: ${name.replace(/[@/"]/g, "\\$&")}\\s+update-types:\\s+- version-update:semver-major`,
+        ),
+      );
+    }
     expect(
-      renovateConfig.packageRules.some((rule) => rule.automerge === true),
-    ).toBe(false);
+      renovateConfig.packageRules.find((rule) =>
+        rule.matchPackageNames?.includes("typescript"),
+      )?.allowedVersions,
+    ).toBe("<7");
+    expect(
+      renovateConfig.packageRules.find((rule) =>
+        rule.matchPackageNames?.includes("@types/node"),
+      )?.allowedVersions,
+    ).toBe("<25");
   });
 
   it("keeps README desktop download links on the versioned Windows release executable", () => {
@@ -94,9 +134,7 @@ describe("repository metadata", () => {
     expect(englishReadme).not.toContain(
       '<a href="https://paydance.vercel.app/"><strong>Live Preview</strong></a>',
     );
-    expect(englishReadme).toContain(
-      'src="posters/poster-02-three-step-setup-en-v1.png"',
-    );
+    expect(englishReadme).toContain('src="posters/poster-02-three-step-setup-en-v1.png"');
     expect(existsInWorktree(posterPath)).toBe(true);
   });
 

--- a/scripts/repository-metadata.test.js
+++ b/scripts/repository-metadata.test.js
@@ -17,6 +17,9 @@ const dependabotSettings = dependabotConfig
   .split(/\r?\n/)
   .filter((line) => !line.trim().startsWith("#"))
   .join("\n");
+// Collapsed so adjacency can be asserted with plain substring matching; building
+// a RegExp from these names would reintroduce js/incomplete-sanitization.
+const collapsedDependabotSettings = dependabotSettings.replace(/\s+/g, " ");
 const versionedDesktopAssetName = `pay-dance-v${packageJson.version}-windows-x64.exe`;
 const desktopDownloadUrl = `https://github.com/MrBaoboer/PayDance/releases/latest/download/${versionedDesktopAssetName}`;
 const legacyAdditionalTermsReference = `see /${["ADDITIONAL_TERMS", "md"].join(".")}`;
@@ -90,10 +93,8 @@ describe("repository metadata", () => {
     expect(packageJson.devDependencies.typescript).toMatch(/^\^6\./);
     expect(packageJson.devDependencies["@types/node"]).toMatch(/^\^24\./);
     for (const name of ["typescript", '"@types/node"']) {
-      expect(dependabotSettings).toMatch(
-        new RegExp(
-          `dependency-name: ${name.replace(/[@/"]/g, "\\$&")}\\s+update-types:\\s+- version-update:semver-major`,
-        ),
+      expect(collapsedDependabotSettings).toContain(
+        `dependency-name: ${name} update-types: - version-update:semver-major`,
       );
     }
     expect(

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -178,9 +178,9 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.91"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@ description = "薪跳 · 桌面实时工资看板"
 authors = ["Mr.Baoboer"]
 license = "AGPL-3.0-only"
 repository = "https://github.com/MrBaoboer/PayDance"
-edition = "2021"
+edition = "2024"
 
 [lib]
 name = "pay_dance_lib"

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -5,9 +5,9 @@
 
 use std::sync::Mutex;
 use tauri::{
+    App, AppHandle, Emitter, Listener, Manager, WebviewWindow, Window, WindowEvent,
     menu::MenuBuilder,
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
-    App, AppHandle, Emitter, Listener, Manager, WebviewWindow, Window, WindowEvent,
 };
 
 const TRAY_OPEN_SETTINGS_EVENT: &str = "tray-open-settings";
@@ -191,13 +191,12 @@ pub(crate) fn setup(app: &mut App) -> Result<(), tauri::Error> {
             let use_en = serde_json::from_str::<String>(event.payload())
                 .map(|locale| locale == "en")
                 .unwrap_or(false);
-            if let Ok(guard) = handle.state::<TrayState>().handle.lock() {
-                if let Some(tray) = guard.as_ref() {
-                    if let Ok(menu) = build_tray_menu(&handle, use_en) {
-                        let _ = tray.set_menu(Some(menu));
-                        let _ = tray.set_tooltip(Some(tray_tooltip(use_en)));
-                    }
-                }
+            if let Ok(guard) = handle.state::<TrayState>().handle.lock()
+                && let Some(tray) = guard.as_ref()
+                && let Ok(menu) = build_tray_menu(&handle, use_en)
+            {
+                let _ = tray.set_menu(Some(menu));
+                let _ = tray.set_tooltip(Some(tray_tooltip(use_en)));
             }
         });
     }


### PR DESCRIPTION
## 背景

按「今天把能升级、有必要升级的一次性都解决」的目标，对 npm、cargo、GitHub Actions、Rust 工具链与依赖更新自动化做了一次完整清点。

## 变更

**依赖**
- `async-trait` 0.1.91 → 0.1.92（Cargo.lock 内唯一可升项）
- `@types/node` 26.2.0 → 24.13.3，对齐 Node 24 LTS 运行时
- 其余 31 个 npm 直接依赖与全部 tauri crate 核对后已是最新

**工具链**
- Rust edition 2021 → 2024（仅两处 `collapsible_if` 由 clippy 自动改写为 let-chains）
- `dtolnay/rust-toolchain` pin 更新至 2026-08-05 的提交；其余 12 个 Action pin 逐个核对 SHA 与 tag，全部吻合
- `.gitattributes` 补 `Cargo.lock text eol=lf`，消除 CRLF/LF 抖动

**依赖更新自动化**
- 新增 `.github/dependabot.yml`，覆盖 npm / cargo / github-actions
- 查证发现 **Renovate 从未在本仓库运行过**：issue #25 的作者是 MrBaoboer 而非 renovate[bot]，`author:app/renovate` 搜索返回 0，23 个历史 PR 无一来自它。`renovate.json` 保留但休眠

**CI**
- security job 中 npm audit 之后的六个步骤加 `if: '!cancelled()'`，一次运行即可拿到四项审计的完整结论

**文档**
- MAINTENANCE 中英文改写依赖更新章节，新增本地工具链对齐一节，留下 2026-10 Node 26 转 LTS 的待办

## 未升级项及原因

| 项 | 原因 |
|---|---|
| `typescript` 7.0.2 | vue-tsc 抛 `ERR_PACKAGE_PATH_NOT_EXPORTED`；typescript-eslint 抛 `does not support TS 7.0` |
| `generic-array` / `toml` / `toml_datetime` / `toml_edit` | 被 `crypto-common 0.1.7`、`proc-macro-crate 2.0.2` 钉死，仅 Linux 目标编译 |
| Node 26 | 2026-10 才转 LTS，届时与 `@types/node` 一并推进 |

## 验证

`npm run verify:release` 全绿（退出码 0）：408 项测试、双 build、`npm audit --audit-level=high` 零公告、cargo fmt/clippy/test/audit/deny 全部通过。本地工具链已同步至 Rust 1.97.1、cargo-audit 0.22.2、cargo-deny 0.20.2、Node 24.19.0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)